### PR TITLE
fix warnings when > 1 year of ref data provided

### DIFF
--- a/R/mwdistdiffzscore.R
+++ b/R/mwdistdiffzscore.R
@@ -227,9 +227,9 @@ mwdistdiffz<-function(testy, refy, wwidth, refwidth=NULL, dx=0.01, stride=1, dmi
           tpd<-refy$tt > ltest | refy$tt <= rtest
         }
 
-        lref<-(refy$doy[abs(refy$tt-wind[ww]) < dt/10]-refwidth*dt/2) %% 365 #left side of reference window
+        lref<-min(refy$doy[abs(refy$tt-wind[ww]) < dt/10]-refwidth*dt/2) %% 365 #left side of reference window
         if(lref==0){lref==365}
-        rref<-(refy$doy[abs(refy$tt-wind[ww]) < dt/10]+refwidth*dt/2) %% 365 #right side of reference window
+        rref<-max(refy$doy[abs(refy$tt-wind[ww]) < dt/10]+refwidth*dt/2) %% 365 #right side of reference window
         if(rref==0){rref==365}
         if(rref > lref){
           rpd<-refy$doy > lref & refy$doy <= rref
@@ -274,10 +274,10 @@ mwdistdiffz<-function(testy, refy, wwidth, refwidth=NULL, dx=0.01, stride=1, dmi
           tpd<-testy$tt > ltest | testy$tt <= rtest
         }
 
-        lref<-(testy$doy[abs(testy$tt-wind[ww]) < dt/10]-refwidth*dt/2) %% 365 #left side of reference window
+        lref<-min(testy$doy[abs(testy$tt-wind[ww]) < dt/10]-refwidth*dt/2) %% 365 #left side of reference window
         if(length(lref)==0){next}#enables skipping indices when time series are gappy
         if(lref==0){lref==365}
-        rref<-(testy$doy[abs(testy$tt-wind[ww]) < dt/10]+refwidth*dt/2) %% 365 #right side of reference window
+        rref<-max(testy$doy[abs(testy$tt-wind[ww]) < dt/10]+refwidth*dt/2) %% 365 #right side of reference window
         if(rref==0){rref==365}
         if(rref > lref){
           rpd<-refy$doy > lref & refy$doy <= rref
@@ -334,10 +334,10 @@ mwdistdiffz<-function(testy, refy, wwidth, refwidth=NULL, dx=0.01, stride=1, dmi
           tpd<-refy$tt > ltest | refy$tt <= rtest
         }
 
-        lref<-(refy$doy[abs(refy$tt-wind[ww]) < dtt/10]-refwidth*dt/2) %% 365 #left side of reference window
+        lref<-min(refy$doy[abs(refy$tt-wind[ww]) < dtt/10]-refwidth*dt/2) %% 365 #left side of reference window
         if(length(lref)==0){next} #enables skipping indices when time series are gappy
         if(lref==0){lref==365}
-        rref<-(refy$doy[abs(refy$tt-wind[ww]) < dtt/10]+refwidth*dt/2) %% 365 #right side of reference window
+        rref<-max(refy$doy[abs(refy$tt-wind[ww]) < dtt/10]+refwidth*dt/2) %% 365 #right side of reference window
         if(rref==0){rref==365}
         if(rref > lref){
           rpd<-refy$doy > lref & refy$doy <= rref
@@ -383,10 +383,10 @@ mwdistdiffz<-function(testy, refy, wwidth, refwidth=NULL, dx=0.01, stride=1, dmi
           tpd<-testy$tt > ltest | testy$tt <= rtest
         }
 
-        lref<-(testy$doy[abs(testy$tt-wind[ww]) < dtt/10]-refwidth*dt/2) %% 365 #left side of reference window
+        lref<-min(testy$doy[abs(testy$tt-wind[ww]) < dtt/10]-refwidth*dt/2) %% 365 #left side of reference window
         if(length(lref)==0){next}#enables skipping indices when time series are gappy
         if(lref==0){lref==365}
-        rref<-(testy$doy[abs(testy$tt-wind[ww]) < dtt/10]+refwidth*dt/2) %% 365 #right side of reference window
+        rref<-max(testy$doy[abs(testy$tt-wind[ww]) < dtt/10]+refwidth*dt/2) %% 365 #right side of reference window
         if(rref==0){rref==365}
         if(rref > lref){
           rpd<-refy$doy > lref & refy$doy <= rref


### PR DESCRIPTION
@jonathan-walter getting rid of warnings that are generated when you provide multiple years of reference data: say you provide three years of daily data, `lref` and `rref` were getting set to vectors with three identical values because `abs(refy$tt-wind[ww]) < dt/10` matched three times. This then leads to warnings when checking e.g., `if(rreff == 0) ` and `if(rref > lref)`.

Shouldn't impact any results or other code in the function since the lref and rreff values were identical, and by default R uses the first value to evaluation the conditional when more than one value is provided.